### PR TITLE
Add staged action plan save flow and guardrails

### DIFF
--- a/app/__tests__/App.spinner.test.tsx
+++ b/app/__tests__/App.spinner.test.tsx
@@ -24,6 +24,6 @@ describe('App initial spinner', () => {
         <App />
       </ToastProvider>
     );
-    expect(await screen.findByText(/Loading Data.../i)).toBeInTheDocument();
+    expect(screen.getByText(/Loading Data.../i)).toBeInTheDocument();
   });
 });

--- a/components/ActionItemsManager.tsx
+++ b/components/ActionItemsManager.tsx
@@ -19,10 +19,25 @@ interface ActionItemsManagerProps {
     onStageChange?: (index: number, updates: Partial<StagedItem>) => void;
     onStageRemove?: (index: number) => void;
     onStageAdd?: (item: StagedItem) => void;
+    onStagePersist?: () => void;
+    isStagePersisting?: boolean;
 }
 
-const ActionItemsManager: React.FC<ActionItemsManagerProps> = ({ 
-    opportunityId, actionItems, users, currentUser, onCreate, onUpdate, onDelete, isDispositioned, stagedDefaults, onStageChange, onStageRemove, onStageAdd 
+const ActionItemsManager: React.FC<ActionItemsManagerProps> = ({
+    opportunityId,
+    actionItems,
+    users,
+    currentUser,
+    onCreate,
+    onUpdate,
+    onDelete,
+    isDispositioned,
+    stagedDefaults,
+    onStageChange,
+    onStageRemove,
+    onStageAdd,
+    onStagePersist,
+    isStagePersisting
 }) => {
     const [newActionText, setNewActionText] = useState('');
     const [editingItemId, setEditingItemId] = useState<string | null>(null);
@@ -222,6 +237,24 @@ const ActionItemsManager: React.FC<ActionItemsManagerProps> = ({
                 <h3 className="text-lg font-semibold text-slate-700">Action Plan</h3>
             </div>
             <div className={`p-6 space-y-4 transition-opacity duration-300 ${isDispositioned ? 'opacity-100' : 'opacity-40 pointer-events-none'}`}>
+                {stagedDefaults && stagedDefaults.length > 0 && (
+                    <div className="p-4 border border-indigo-300 bg-indigo-50 rounded-md flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                        <div>
+                            <p className="text-sm font-semibold text-indigo-900">Action plan staged</p>
+                            <p className="text-xs text-indigo-700">Review the pending tasks below, then save them to add to the action plan.</p>
+                        </div>
+                        {onStagePersist && (
+                            <button
+                                type="button"
+                                onClick={onStagePersist}
+                                className="inline-flex items-center justify-center px-4 py-2 text-sm font-semibold text-white bg-indigo-600 rounded-md shadow hover:bg-indigo-700 disabled:opacity-60 disabled:cursor-not-allowed"
+                                disabled={isStagePersisting}
+                            >
+                                {isStagePersisting ? 'Saving…' : 'Save Action Plan'}
+                            </button>
+                        )}
+                    </div>
+                )}
                 <div>
                     <form onSubmit={handleActionItemAdd} className="flex space-x-2">
                         <input

--- a/components/DispositionForm.tsx
+++ b/components/DispositionForm.tsx
@@ -7,7 +7,7 @@ interface DispositionFormProps {
     onSave: (disposition: Disposition) => void;
     opportunity: Opportunity;
     lastUpdatedBy?: string;
-    onStatusChange?: (status: DispositionStatus) => void;
+    onStatusChange?: (status: DispositionStatus) => boolean | void;
 }
 
 const DispositionForm: React.FC<DispositionFormProps> = ({ onSave, opportunity, lastUpdatedBy, onStatusChange }) => {
@@ -18,7 +18,8 @@ const DispositionForm: React.FC<DispositionFormProps> = ({ onSave, opportunity, 
   }, [opportunity.disposition]);
 
   const handleSetDispositionStatus = (status: DispositionStatus) => {
-    if (onStatusChange) onStatusChange(status);
+    const allowChange = onStatusChange ? onStatusChange(status) : true;
+    if (allowChange === false) return;
     setDisposition(prev => {
         const newState = {...prev, status};
         if (status === 'Services Fit') {

--- a/components/__tests__/ActionItemsManager.stagedAdd.test.tsx
+++ b/components/__tests__/ActionItemsManager.stagedAdd.test.tsx
@@ -27,6 +27,7 @@ describe('ActionItemsManager - staged add', () => {
         onStageChange={vi.fn()}
         onStageRemove={vi.fn()}
         onStageAdd={onStageAdd}
+        onStagePersist={vi.fn()}
       />
     );
 
@@ -36,6 +37,36 @@ describe('ActionItemsManager - staged add', () => {
 
     expect(onCreate).not.toHaveBeenCalled();
     expect(onStageAdd).toHaveBeenCalledWith({ name: 'Follow-up email', status: ActionItemStatus.NotStarted, due_date: '', notes: '' });
+  });
+
+  it('shows a save CTA when staged defaults exist', () => {
+    const onStagePersist = vi.fn();
+
+    render(
+      <ActionItemsManager
+        opportunityId="opp1"
+        actionItems={[] as ActionItem[]}
+        users={users}
+        currentUser={users[0]}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+        isDispositioned={true}
+        stagedDefaults={[
+          { name: 'Contact Opp Owner', status: ActionItemStatus.NotStarted, due_date: '', notes: '' },
+          { name: 'Share proposal', status: ActionItemStatus.NotStarted, due_date: '', notes: '' },
+        ]}
+        onStageChange={vi.fn()}
+        onStageRemove={vi.fn()}
+        onStageAdd={vi.fn()}
+        onStagePersist={onStagePersist}
+      />
+    );
+
+    const saveButton = screen.getByRole('button', { name: /save action plan/i });
+    expect(saveButton).toBeInTheDocument();
+    fireEvent.click(saveButton);
+    expect(onStagePersist).toHaveBeenCalled();
   });
 });
 

--- a/components/__tests__/OpportunityDetail.historySummary.test.tsx
+++ b/components/__tests__/OpportunityDetail.historySummary.test.tsx
@@ -5,6 +5,18 @@ import type { Opportunity, AccountDetails, User, ActionItem } from '../../types'
 
 const user: User = { user_id: 'u1', name: 'Tester', email: 't@example.com' };
 
+const showToastSpy = vi.fn();
+
+vi.mock('../../components/Toast', () => ({
+  ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useToast: () => ({ showToast: showToastSpy }),
+}));
+
+beforeEach(() => {
+  showToastSpy.mockClear();
+  window.scrollTo = vi.fn();
+});
+
 const opp = (overrides: Partial<Opportunity>): Opportunity => ({
   opportunities_id: 'id-' + Math.random(),
   opportunities_name: 'Opp',

--- a/components/__tests__/OpportunityDetail.supportSummary.test.tsx
+++ b/components/__tests__/OpportunityDetail.supportSummary.test.tsx
@@ -5,6 +5,18 @@ import type { Opportunity, AccountDetails, User, ActionItem, SupportTicket } fro
 
 const user: User = { user_id: 'u1', name: 'Tester', email: 't@example.com' };
 
+const showToastSpy = vi.fn();
+
+vi.mock('../../components/Toast', () => ({
+  ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useToast: () => ({ showToast: showToastSpy }),
+}));
+
+beforeEach(() => {
+  showToastSpy.mockClear();
+  window.scrollTo = vi.fn();
+});
+
 const baseOpp = (overrides: Partial<Opportunity> = {}): Opportunity => ({
   opportunities_id: 'opp1',
   opportunities_name: 'Test Opp',


### PR DESCRIPTION
## Summary
- add a Save Action Plan banner/button in `ActionItemsManager` and wire an `onStagePersist` callback for staged defaults
- update `OpportunityDetail` to persist staged tasks with toasts, block navigation while unsaved items exist, and adapt `DispositionForm` to allow cancelling status changes
- refresh related tests to cover the CTA, staged persistence, guard prompts, and stabilize the app spinner test

## Testing
- `npx vitest run --reporter verbose`


------
https://chatgpt.com/codex/tasks/task_b_68d19bc32710832dbd8162c4b11a57c3