### PR TITLE
Refine action plan editor and due-date styling

### DIFF
--- a/components/ActionItemsManager.tsx
+++ b/components/ActionItemsManager.tsx
@@ -1,132 +1,39 @@
-
 import React, { useMemo, useState } from 'react';
-import type { ActionItem, User } from '../types';
+import type { User } from '../types';
 import { ActionItemStatus } from '../types';
 import { ICONS } from '../constants';
-import type { StagedActionItem } from './disposition/DispositionActionPlanContext';
+import { useDispositionActionPlan } from './disposition/DispositionActionPlanContext';
+import { getDueDateColorClasses, getDueDateDescriptor } from './disposition/dateUtils';
 
 interface ActionItemsManagerProps {
     users: User[];
-    isDispositioned: boolean;
-    actionItems: ActionItem[];
-    stagedActionItems: StagedActionItem[];
-    isStagePersisting: boolean;
-    onAddStagedActionItem: (item: Partial<StagedActionItem>) => void;
-    onUpdateStagedActionItem: (index: number, updates: Partial<StagedActionItem>) => void;
-    onRemoveStagedActionItem: (index: number) => void;
-    onPersistStagedActionItems: () => void;
-    onCreateActionItem: (name: string) => void | Promise<void>;
-    onUpdateActionItem: (itemId: string, updates: Partial<ActionItem>) => void | Promise<void>;
-    onDeleteActionItem: (itemId: string) => void | Promise<void>;
 }
 
-const ActionItemsManager: React.FC<ActionItemsManagerProps> = ({
-    users,
-    isDispositioned,
-    actionItems,
-    stagedActionItems,
-    isStagePersisting,
-    onAddStagedActionItem,
-    onUpdateStagedActionItem,
-    onRemoveStagedActionItem,
-    onPersistStagedActionItems,
-    onCreateActionItem,
-    onUpdateActionItem,
-    onDeleteActionItem,
-}) => {
+const DEFAULT_ORDER = new Map<string, number>([
+    ['contact opp owner', 0],
+    ['scope and develop proposal', 1],
+    ['share proposal', 2],
+    ['finalize proposal', 3],
+    ['ironclad approvals', 4],
+    ['ironclad approval', 4],
+]);
+
+const ActionItemsManager: React.FC<ActionItemsManagerProps> = ({ users }) => {
+    const {
+        isDispositioned,
+        actionItems,
+        stagedActionItems,
+        addStagedActionItem,
+        updateStagedActionItem,
+        removeStagedActionItem,
+        updateActionItem,
+        deleteActionItem,
+        isStagePersisting,
+        currentUser,
+    } = useDispositionActionPlan();
     const [newActionText, setNewActionText] = useState('');
-    const [editingItemId, setEditingItemId] = useState<string | null>(null);
-    const [expandedStagedIdx, setExpandedStagedIdx] = useState<number | null>(null);
 
-    const handleActionItemAdd = (e: React.FormEvent) => {
-        e.preventDefault();
-        const trimmed = newActionText.trim();
-        if (!trimmed) return;
-
-        if (stagedActionItems && stagedActionItems.length > 0 && (actionItems?.length || 0) === 0) {
-            onAddStagedActionItem({ name: trimmed, status: ActionItemStatus.NotStarted, due_date: '', notes: '' });
-            setEditingItemId(null);
-            setExpandedStagedIdx(stagedActionItems.length);
-        } else {
-            onCreateActionItem(trimmed);
-        }
-        setNewActionText('');
-    };
-
-    const handleUpdate = (itemId: string, updates: Partial<ActionItem>) => {
-        onUpdateActionItem(itemId, updates);
-    };
-
-    const renderActionItem = (item: ActionItem) => {
-        const isEditing = editingItemId === item.action_item_id;
-        const createdBy = users.find(u => u.user_id === item.created_by_user_id)?.name || 'Unknown';
-
-        return (
-            <div key={item.action_item_id} className="p-3 bg-white rounded-md shadow-sm border">
-                <div className="flex items-center justify-between">
-                    <div className="flex items-center flex-grow min-w-0">
-                        <input
-                            type="checkbox"
-                            checked={item.status === ActionItemStatus.Completed}
-                            onChange={() => handleUpdate(item.action_item_id, { status: item.status === ActionItemStatus.Completed ? ActionItemStatus.NotStarted : ActionItemStatus.Completed })}
-                            className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500 flex-shrink-0"
-                        />
-                        <span className={`ml-3 text-sm font-medium ${item.status === ActionItemStatus.Completed ? 'line-through text-slate-400' : 'text-slate-800'}`}>
-                            {item.name}
-                        </span>
-                    </div>
-                    <div className="flex items-center space-x-2">
-                         <button
-                            onClick={() => {
-                                setExpandedStagedIdx(null);
-                                setEditingItemId(isEditing ? null : item.action_item_id);
-                            }}
-                            className="text-slate-400 hover:text-indigo-600 p-1"
-                         >{ICONS.edit}</button>
-                        <button onClick={() => onDeleteActionItem(item.action_item_id)} className="text-slate-400 hover:text-red-500 p-1">{ICONS.trash}</button>
-                    </div>
-                </div>
-                 {isEditing && (
-                    <div className="mt-3 pt-3 border-t animate-fade-in space-y-4">
-                        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                            <div>
-                                <label className="text-xs font-medium text-slate-600">Status</label>
-                                <select value={item.status} onChange={(e) => handleUpdate(item.action_item_id, { status: e.target.value as ActionItemStatus })} className="mt-1 w-full p-1 text-sm border-slate-300 rounded-md">
-                                    {Object.values(ActionItemStatus).map(s => <option key={s} value={s}>{s}</option>)}
-                                </select>
-                            </div>
-                            <div>
-                                <label className="text-xs font-medium text-slate-600">Assign To</label>
-                                <select value={item.assigned_to_user_id} onChange={(e) => handleUpdate(item.action_item_id, { assigned_to_user_id: e.target.value })} className="mt-1 w-full p-1 text-sm border-slate-300 rounded-md">
-                                    {users.map(user => <option key={user.user_id} value={user.user_id}>{user.name}</option>)}
-                                </select>
-                            </div>
-                             <div>
-                                <label className="text-xs font-medium text-slate-600">Due Date</label>
-                                <input type="date" value={item.due_date} onChange={(e) => handleUpdate(item.action_item_id, { due_date: e.target.value })} className="mt-1 w-full p-1 text-sm border-slate-300 rounded-md" />
-                            </div>
-                        </div>
-                        <div>
-                            <label className="text-xs font-medium text-slate-600">Notes</label>
-                            <textarea rows={2} value={item.notes || ''} onChange={(e) => handleUpdate(item.action_item_id, { notes: e.target.value })} className="w-full p-1 text-sm border-slate-300 rounded-md mt-1" placeholder="Add notes..."/>
-                        </div>
-                        <p className="text-right text-xs text-slate-400">Created by: {createdBy}</p>
-                    </div>
-                 )}
-            </div>
-        );
-    };
-
-    const DEFAULT_ORDER = useMemo(() => new Map<string, number>([
-        ['contact opp owner', 0],
-        ['scope and develop proposal', 1],
-        ['share proposal', 2],
-        ['finalize proposal', 3],
-        ['ironclad approvals', 4],
-        ['ironclad approval', 4],
-    ]), []);
-
-    const displayed = useMemo(() => {
+    const sortedActionItems = useMemo(() => {
         const items = [...actionItems];
         items.sort((a, b) => {
             const ai = DEFAULT_ORDER.get((a.name || '').trim().toLowerCase());
@@ -137,130 +44,326 @@ const ActionItemsManager: React.FC<ActionItemsManagerProps> = ({
             return 0;
         });
         return items;
-    }, [actionItems, DEFAULT_ORDER]);
+    }, [actionItems]);
 
-    const renderStagedItem = (item: StagedActionItem, idx: number) => {
-        const expanded = expandedStagedIdx === idx;
+    const disableInteractions = !isDispositioned || isStagePersisting;
+
+    const handleActionItemAdd = (e: React.FormEvent) => {
+        e.preventDefault();
+        const trimmed = newActionText.trim();
+        if (!trimmed || disableInteractions) return;
+
+        addStagedActionItem({ name: trimmed });
+        setNewActionText('');
+    };
+
+    const renderDueDescriptor = (identifier: string, dueDate: string | null | undefined) => {
+        const descriptor = getDueDateDescriptor(dueDate);
         return (
-            <div key={`staged-${idx}`} className="p-3 bg-white rounded-md shadow-sm border border-dashed">
-                <div className="flex items-center justify-between">
-                    <div className="flex items-center flex-grow min-w-0">
-                        <input type="checkbox" disabled className="h-4 w-4 rounded border-slate-300 text-indigo-600 flex-shrink-0" />
-                        {expanded ? (
+            <span
+                id={identifier}
+                className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold ${getDueDateColorClasses(
+                    dueDate
+                )}`}
+            >
+                {descriptor}
+            </span>
+        );
+    };
+
+    const renderPersistedItem = (index: number) => {
+        const item = sortedActionItems[index];
+        const createdBy = users.find(u => u.user_id === item.created_by_user_id)?.name || 'Unknown';
+        const dueDescriptorId = `persisted-${item.action_item_id}-due`;
+
+        return (
+            <article key={item.action_item_id} className="rounded-md border border-slate-200 bg-white p-4 shadow-sm">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="flex flex-1 items-start gap-3">
+                        <input
+                            type="checkbox"
+                            className="mt-1 h-4 w-4 flex-shrink-0 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+                            checked={item.status === ActionItemStatus.Completed}
+                            onChange={() =>
+                                updateActionItem(item.action_item_id, {
+                                    status:
+                                        item.status === ActionItemStatus.Completed
+                                            ? ActionItemStatus.NotStarted
+                                            : ActionItemStatus.Completed,
+                                })
+                            }
+                            disabled={disableInteractions}
+                            aria-label={item.status === ActionItemStatus.Completed ? 'Mark task incomplete' : 'Mark task complete'}
+                        />
+                        <div className="min-w-0 flex-1">
+                            <p
+                                className={`text-sm font-semibold ${
+                                    item.status === ActionItemStatus.Completed ? 'line-through text-slate-400' : 'text-slate-800'
+                                }`}
+                            >
+                                {item.name}
+                            </p>
+                            <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-slate-500">
+                                <span>Created by {createdBy}</span>
+                                {renderDueDescriptor(dueDescriptorId, item.due_date)}
+                            </div>
+                        </div>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={() => deleteActionItem(item.action_item_id)}
+                        className="inline-flex items-center rounded-md p-1 text-slate-400 transition hover:text-red-600"
+                        aria-label={`Delete task ${item.name}`}
+                        disabled={isStagePersisting}
+                    >
+                        {ICONS.trash}
+                    </button>
+                </div>
+                <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                    <label className="flex flex-col text-xs font-medium text-slate-600">
+                        <span>Status</span>
+                        <select
+                            value={item.status}
+                            onChange={event =>
+                                updateActionItem(item.action_item_id, {
+                                    status: event.target.value as ActionItemStatus,
+                                })
+                            }
+                            className="mt-1 w-full rounded-md border border-slate-300 p-2 text-sm"
+                            disabled={disableInteractions}
+                        >
+                            {Object.values(ActionItemStatus).map(status => (
+                                <option key={status} value={status}>
+                                    {status}
+                                </option>
+                            ))}
+                        </select>
+                    </label>
+                    <label className="flex flex-col text-xs font-medium text-slate-600">
+                        <span>Assignee</span>
+                        <select
+                            value={item.assigned_to_user_id}
+                            onChange={event =>
+                                updateActionItem(item.action_item_id, {
+                                    assigned_to_user_id: event.target.value,
+                                })
+                            }
+                            className="mt-1 w-full rounded-md border border-slate-300 p-2 text-sm"
+                            disabled={disableInteractions}
+                        >
+                            {users.map(user => (
+                                <option key={user.user_id} value={user.user_id}>
+                                    {user.name}
+                                </option>
+                            ))}
+                        </select>
+                    </label>
+                    <label className="flex flex-col text-xs font-medium text-slate-600">
+                        <span>Due date</span>
+                        <input
+                            type="date"
+                            value={item.due_date || ''}
+                            onChange={event =>
+                                updateActionItem(item.action_item_id, {
+                                    due_date: event.target.value,
+                                })
+                            }
+                            className="mt-1 w-full rounded-md border border-slate-300 p-2 text-sm"
+                            aria-describedby={dueDescriptorId}
+                            disabled={disableInteractions}
+                        />
+                    </label>
+                    <label className="flex flex-col text-xs font-medium text-slate-600 sm:col-span-2 lg:col-span-1">
+                        <span>Notes</span>
+                        <textarea
+                            value={item.notes || ''}
+                            onChange={event =>
+                                updateActionItem(item.action_item_id, {
+                                    notes: event.target.value,
+                                })
+                            }
+                            rows={2}
+                            className="mt-1 w-full rounded-md border border-slate-300 p-2 text-sm"
+                            placeholder="Add notes"
+                            disabled={disableInteractions}
+                        />
+                    </label>
+                </div>
+            </article>
+        );
+    };
+
+    const renderStagedItem = (index: number) => {
+        const item = stagedActionItems[index];
+        const dueDescriptorId = `staged-${index}-due`;
+
+        return (
+            <article
+                key={`staged-${index}`}
+                className="rounded-md border border-dashed border-indigo-300 bg-indigo-50/80 p-4 shadow-sm"
+            >
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="flex flex-1 items-start gap-3">
+                        <input
+                            type="checkbox"
+                            className="mt-1 h-4 w-4 flex-shrink-0 rounded border-slate-300"
+                            disabled
+                            aria-label="Unsaved task"
+                        />
+                        <div className="min-w-0 flex-1">
                             <input
                                 type="text"
                                 value={item.name}
-                                onChange={(e) => onUpdateStagedActionItem(idx, { name: e.target.value })}
-                                className="ml-3 flex-grow min-w-0 p-1 text-sm border border-slate-300 rounded-md"
+                                onChange={event => updateStagedActionItem(index, { name: event.target.value })}
+                                className="w-full rounded-md border border-indigo-200 bg-white px-3 py-2 text-sm font-semibold text-slate-800 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
                                 placeholder="Task title"
+                                disabled={disableInteractions}
                             />
-                        ) : (
-                            <span className="ml-3 text-sm font-medium text-slate-800 truncate">{item.name}</span>
-                        )}
+                            <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-indigo-700">
+                                <span className="inline-flex items-center rounded-full bg-indigo-200/70 px-2 py-0.5 font-semibold text-indigo-900">
+                                    Unsaved task – save changes to persist
+                                </span>
+                                {renderDueDescriptor(dueDescriptorId, item.due_date)}
+                            </div>
+                        </div>
                     </div>
-                    <div className="flex items-center space-x-2">
-                        <button
-                            type="button"
-                            onClick={() => {
-                                setEditingItemId(null);
-                                setExpandedStagedIdx(expanded ? null : idx);
-                            }}
-                            className="text-slate-400 hover:text-indigo-600 p-1"
-                            title={expanded ? 'Collapse' : 'Edit'}
-                        >
-                            {ICONS.edit}
-                        </button>
-                        <button type="button" onClick={() => onRemoveStagedActionItem(idx)} className="text-slate-400 hover:text-red-500 p-1" title="Remove">
-                            {ICONS.trash}
-                        </button>
-                        <span className="text-xs text-slate-500">Pending save</span>
-                    </div>
+                    <button
+                        type="button"
+                        onClick={() => removeStagedActionItem(index)}
+                        className="inline-flex items-center rounded-md p-1 text-indigo-500 transition hover:text-red-600"
+                        aria-label={`Remove unsaved task ${item.name || index + 1}`}
+                        disabled={disableInteractions}
+                    >
+                        {ICONS.trash}
+                    </button>
                 </div>
-                {expanded && (
-                    <div className="mt-3 pt-3 border-t grid grid-cols-1 sm:grid-cols-3 gap-4">
-                        <div>
-                            <label className="text-xs font-medium text-slate-600">Status</label>
-                            <select
-                                value={item.status}
-                                onChange={(e) => onUpdateStagedActionItem(idx, { status: e.target.value as ActionItemStatus })}
-                                className="mt-1 w-full p-1 text-sm border-slate-300 rounded-md"
-                            >
-                                {Object.values(ActionItemStatus).map(s => <option key={s} value={s}>{s}</option>)}
-                            </select>
-                        </div>
-                        <div>
-                            <label className="text-xs font-medium text-slate-600">Due Date</label>
-                            <input
-                                type="date"
-                                value={item.due_date}
-                                onChange={(e) => onUpdateStagedActionItem(idx, { due_date: e.target.value })}
-                                className="mt-1 w-full p-1 text-sm border-slate-300 rounded-md"
-                            />
-                        </div>
-                        <div className="sm:col-span-3">
-                            <label className="text-xs font-medium text-slate-600">Notes</label>
-                            <textarea
-                                rows={2}
-                                value={item.notes}
-                                onChange={(e) => onUpdateStagedActionItem(idx, { notes: e.target.value })}
-                                className="w-full p-1 text-sm border-slate-300 rounded-md mt-1"
-                                placeholder="Add notes..."
-                            />
-                        </div>
-                    </div>
-                )}
-            </div>
+                <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                    <label className="flex flex-col text-xs font-medium text-slate-600">
+                        <span>Status</span>
+                        <select
+                            value={item.status}
+                            onChange={event =>
+                                updateStagedActionItem(index, {
+                                    status: event.target.value as ActionItemStatus,
+                                })
+                            }
+                            className="mt-1 w-full rounded-md border border-indigo-200 bg-white p-2 text-sm"
+                            disabled={disableInteractions}
+                        >
+                            {Object.values(ActionItemStatus).map(status => (
+                                <option key={status} value={status}>
+                                    {status}
+                                </option>
+                            ))}
+                        </select>
+                    </label>
+                    <label className="flex flex-col text-xs font-medium text-slate-600">
+                        <span>Assignee</span>
+                        <select
+                            value={item.assigned_to_user_id || currentUser.user_id}
+                            onChange={event =>
+                                updateStagedActionItem(index, {
+                                    assigned_to_user_id: event.target.value,
+                                })
+                            }
+                            className="mt-1 w-full rounded-md border border-indigo-200 bg-white p-2 text-sm"
+                            disabled={disableInteractions}
+                        >
+                            {users.map(user => (
+                                <option key={user.user_id} value={user.user_id}>
+                                    {user.name}
+                                </option>
+                            ))}
+                        </select>
+                    </label>
+                    <label className="flex flex-col text-xs font-medium text-slate-600">
+                        <span>Due date</span>
+                        <input
+                            type="date"
+                            value={item.due_date || ''}
+                            onChange={event => updateStagedActionItem(index, { due_date: event.target.value })}
+                            className="mt-1 w-full rounded-md border border-indigo-200 bg-white p-2 text-sm"
+                            aria-describedby={dueDescriptorId}
+                            disabled={disableInteractions}
+                        />
+                    </label>
+                    <label className="flex flex-col text-xs font-medium text-slate-600 sm:col-span-2 lg:col-span-1">
+                        <span>Notes</span>
+                        <textarea
+                            value={item.notes}
+                            onChange={event => updateStagedActionItem(index, { notes: event.target.value })}
+                            rows={2}
+                            className="mt-1 w-full rounded-md border border-indigo-200 bg-white p-2 text-sm"
+                            placeholder="Add notes"
+                            disabled={disableInteractions}
+                        />
+                    </label>
+                </div>
+            </article>
         );
     };
 
     return (
-        <div className="bg-white rounded-lg shadow-lg">
-            <div className="p-4 bg-slate-50 border-b flex items-center space-x-3">
+        <section className="rounded-lg bg-white shadow-lg" aria-labelledby="action-plan-heading">
+            <div className="flex items-center space-x-3 border-b bg-slate-50 p-4">
                 {ICONS.listBullet}
-                <h3 className="text-lg font-semibold text-slate-700">Action Plan</h3>
+                <h3 id="action-plan-heading" className="text-lg font-semibold text-slate-700">
+                    Action plan
+                </h3>
             </div>
-            <div className={`p-6 space-y-4 transition-opacity duration-300 ${isDispositioned ? 'opacity-100' : 'opacity-40 pointer-events-none'}`}>
-                {stagedActionItems && stagedActionItems.length > 0 && (
-                    <div className="p-4 border border-indigo-300 bg-indigo-50 rounded-md flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+            <div
+                className={`space-y-4 p-6 transition-opacity duration-300 ${
+                    isDispositioned ? 'opacity-100' : 'opacity-40 pointer-events-none'
+                }`}
+            >
+                {stagedActionItems.length > 0 && (
+                    <div className="flex flex-col gap-3 rounded-md border border-indigo-200 bg-indigo-50/90 p-4 text-sm text-indigo-900 sm:flex-row sm:items-center sm:justify-between">
                         <div>
-                            <p className="text-sm font-semibold text-indigo-900">Action plan staged</p>
-                            <p className="text-xs text-indigo-700">Review the pending tasks below, then save them to add to the action plan.</p>
+                            <p className="font-semibold">Unsaved action plan tasks</p>
+                            <p className="text-xs text-indigo-700">
+                                Review tasks and press Save changes above to add them to this opportunity.
+                            </p>
                         </div>
-                        <button
-                                type="button"
-                                onClick={onPersistStagedActionItems}
-                                className="inline-flex items-center justify-center px-4 py-2 text-sm font-semibold text-white bg-indigo-600 rounded-md shadow hover:bg-indigo-700 disabled:opacity-60 disabled:cursor-not-allowed"
-                                disabled={isStagePersisting}
-                            >
-                                {isStagePersisting ? 'Saving…' : 'Save Action Plan'}
-                        </button>
+                        {isStagePersisting && (
+                            <span className="inline-flex items-center rounded-full bg-indigo-200 px-3 py-1 text-xs font-semibold text-indigo-900">
+                                Saving…
+                            </span>
+                        )}
                     </div>
                 )}
-                <div>
-                    <form onSubmit={handleActionItemAdd} className="flex space-x-2">
+                <form onSubmit={handleActionItemAdd} className="flex flex-col gap-2 sm:flex-row">
+                    <label className="flex-1 text-sm text-slate-600">
+                        <span className="sr-only">New task name</span>
                         <input
                             type="text"
-                            className="flex-grow p-2 border border-slate-300 rounded-md shadow-sm"
-                            placeholder="Add a new task..."
+                            className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                            placeholder="Add a new task"
                             value={newActionText}
-                            onChange={e => setNewActionText(e.target.value)}
-                            disabled={!isDispositioned}
+                            onChange={event => setNewActionText(event.target.value)}
+                            disabled={!isDispositioned || isStagePersisting}
                         />
-                        <button type="submit" className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 font-semibold" disabled={!isDispositioned}>Add</button>
-                    </form>
-                </div>
-                <div className="space-y-3 max-h-96 overflow-y-auto pr-2">
-                    {stagedActionItems && stagedActionItems.length > 0 && stagedActionItems.map((item, idx) => renderStagedItem(item, idx))}
-                    {(!stagedActionItems || stagedActionItems.length === 0) && displayed.length === 0 && (
-                        <div className="text-center py-10 text-slate-400 text-sm">
+                    </label>
+                    <button
+                        type="submit"
+                        className="inline-flex items-center justify-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-indigo-300"
+                        disabled={!isDispositioned || isStagePersisting || newActionText.trim().length === 0}
+                    >
+                        Add task
+                    </button>
+                </form>
+                <div className="space-y-4" aria-live="polite">
+                    {stagedActionItems.map((_, index) => renderStagedItem(index))}
+                    {sortedActionItems.length === 0 && stagedActionItems.length === 0 ? (
+                        <div className="rounded-md border border-dashed border-slate-200 p-10 text-center text-sm text-slate-500">
                             <p>No action items yet.</p>
-                            <p>Set disposition to "Services Fit" to add tasks.</p>
+                            <p className="mt-1">Set disposition to “Services Fit” to start building an action plan.</p>
                         </div>
+                    ) : (
+                        sortedActionItems.map((_, index) => renderPersistedItem(index))
                     )}
-                    {displayed.map(renderActionItem)}
                 </div>
             </div>
-        </div>
+        </section>
     );
 };
 

--- a/components/OpportunityDetail.tsx
+++ b/components/OpportunityDetail.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useState, useEffect, useRef, useLayoutEffect, useCallback } from 'react';
 import type { Opportunity, AccountDetails, SupportTicket, UsageData, ProjectHistory, Disposition, User, ActionItem } from '../types';
-import { ActionItemStatus } from '../types';
 import Card from './Card';
 import Tag from './Tag';
 import DispositionForm from './DispositionForm';
@@ -530,25 +529,7 @@ const HistoricalOpportunitiesList: React.FC<{ opportunities: Opportunity[] }> = 
 const OpportunityDetailInner: React.FC<OpportunityDetailInnerProps> = ({ opportunity, details, historicalOpportunities, onBack, users, initialSectionId }) => {
     const [activeSection, setActiveSection] = useState(initialSectionId || 'usage-history');
     const sectionRefs = useRef<Record<string, HTMLElement | null>>({});
-    const {
-        confirmDiscardStaged,
-        confirmDiscardChanges,
-        draftDisposition,
-        changeDispositionStatus,
-        updateDisposition,
-        actionItems,
-        stagedActionItems,
-        addStagedActionItem,
-        updateStagedActionItem,
-        removeStagedActionItem,
-        persistStagedActionItems,
-        isStagePersisting,
-        isDispositioned,
-        createActionItem,
-        updateActionItem,
-        deleteActionItem,
-        currentUser,
-    } = useDispositionActionPlan();
+    const { confirmDiscardChanges, draftDisposition, changeDispositionStatus, updateDisposition } = useDispositionActionPlan();
 
     useEffect(() => {
         const observer = new IntersectionObserver(
@@ -598,20 +579,6 @@ const OpportunityDetailInner: React.FC<OpportunityDetailInnerProps> = ({ opportu
 
     const lookerUrl = `https://fivetran.looker.com/dashboards/1328?Salesforce+Account+Name=&Salesforce+Account+ID=${opportunity.accounts_salesforce_account_id}&Fivetran+Account+ID=`;
     const sePovUrl = `https://pov-app.fivetran-internal-sales.com/opportunity/${opportunity.opportunities_id}`;
-
-    const handleCreateActionItem = useCallback(
-        (name: string) =>
-            createActionItem({
-                opportunity_id: opportunity.opportunities_id,
-                name,
-                status: ActionItemStatus.NotStarted,
-                due_date: '',
-                notes: '',
-                documents: [],
-                assigned_to_user_id: currentUser.user_id,
-            }),
-        [createActionItem, currentUser.user_id, opportunity.opportunities_id]
-    );
 
     const usageHistoryTitle = (
         <a href={lookerUrl} target="_blank" rel="noopener noreferrer" className="flex items-center space-x-2 group text-slate-700 hover:text-indigo-600 transition-colors">
@@ -778,20 +745,7 @@ const OpportunityDetailInner: React.FC<OpportunityDetailInnerProps> = ({ opportu
                                 lastUpdatedBy={lastUpdatedByName}
                             />
                             <div id="action-items" style={{ scrollMarginTop: 90 }}>
-                                <ActionItemsManager
-                                    users={users}
-                                    isDispositioned={isDispositioned}
-                                    actionItems={actionItems}
-                                    stagedActionItems={stagedActionItems}
-                                    isStagePersisting={isStagePersisting}
-                                    onAddStagedActionItem={addStagedActionItem}
-                                    onUpdateStagedActionItem={updateStagedActionItem}
-                                    onRemoveStagedActionItem={removeStagedActionItem}
-                                    onPersistStagedActionItems={persistStagedActionItems}
-                                    onCreateActionItem={handleCreateActionItem}
-                                    onUpdateActionItem={updateActionItem}
-                                    onDeleteActionItem={deleteActionItem}
-                                />
+                                <ActionItemsManager users={users} />
                             </div>
                         </div>
                     </div>

--- a/components/TaskCockpit.tsx
+++ b/components/TaskCockpit.tsx
@@ -3,6 +3,7 @@ import React, { useState, useMemo } from 'react';
 import type { TaskWithOpportunityContext, ActionItem, User } from '../types';
 import { ActionItemStatus } from '../types';
 import { ICONS } from '../constants';
+import { getDueDateColorClasses, getDueDateDescriptor } from './disposition/dateUtils';
 
 interface TaskCockpitProps {
     tasks: TaskWithOpportunityContext[];
@@ -11,13 +12,6 @@ interface TaskCockpitProps {
     users: User[];
     currentUser: User;
 }
-
-const formatDate = (dateString: string) => {
-    if (!dateString) return 'No due date';
-    const date = new Date(dateString);
-    const utcDate = new Date(date.getTime() + date.getTimezoneOffset() * 60000);
-    return utcDate.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
-};
 
 const TaskCockpit: React.FC<TaskCockpitProps> = ({ tasks, onTaskUpdate, onSelectOpportunity, users, currentUser }) => {
     const [viewMode, setViewMode] = useState<'date' | 'opportunity'>('date');
@@ -43,42 +37,114 @@ const TaskCockpit: React.FC<TaskCockpitProps> = ({ tasks, onTaskUpdate, onSelect
     
     const getAssigneeName = (userId: string) => users.find(u => u.user_id === userId)?.name || 'Unknown';
 
-    const renderTaskItem = (task: TaskWithOpportunityContext) => (
-        <div key={task.action_item_id} className="p-3 bg-white rounded-md shadow-sm border border-slate-200">
-            <div className="flex items-start justify-between space-x-4">
-                <div className="flex-grow min-w-0">
-                    <p className={`font-semibold text-slate-800 ${task.status === ActionItemStatus.Completed ? 'line-through text-slate-400' : ''}`}>{task.name}</p>
-                    {viewMode === 'date' && (
-                        <p className="text-xs text-slate-500 mt-1">For: <button onClick={() => onSelectOpportunity(task.opportunityId)} className="font-semibold text-indigo-600 hover:underline">{task.opportunityName}</button> ({task.accountName})</p>
-                    )}
-                </div>
-                <div className="flex items-center space-x-4 flex-shrink-0">
-                    <div className="flex items-center space-x-2">
-                        <span className="text-xs text-slate-500">Assignee:</span>
-                        <select 
-                            value={task.assigned_to_user_id} 
-                            onChange={(e) => onTaskUpdate(task.action_item_id, task.opportunityId, { assigned_to_user_id: e.target.value })}
-                            className="text-sm p-1 border border-slate-300 rounded-md bg-white w-32"
-                            onClick={(e) => e.stopPropagation()}
+    const renderTaskItem = (task: TaskWithOpportunityContext) => {
+        const dueDescriptor = getDueDateDescriptor(task.due_date);
+        const dueClasses = getDueDateColorClasses(task.due_date);
+
+        return (
+            <div key={task.action_item_id} className="p-3 bg-white rounded-md shadow-sm border border-slate-200">
+                <div className="flex items-start justify-between space-x-4">
+                    <div className="flex-grow min-w-0">
+                        <p
+                            className={`font-semibold text-slate-800 ${
+                                task.status === ActionItemStatus.Completed ? 'line-through text-slate-400' : ''
+                            }`}
                         >
-                            {users.map(user => <option key={user.user_id} value={user.user_id}>{user.name}</option>)}
+                            {task.name}
+                        </p>
+                        <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-slate-500">
+                            {viewMode === 'date' && (
+                                <span>
+                                    For:{' '}
+                                    <button
+                                        onClick={() => onSelectOpportunity(task.opportunityId)}
+                                        className="font-semibold text-indigo-600 hover:underline"
+                                    >
+                                        {task.opportunityName}
+                                    </button>{' '}
+                                    ({task.accountName})
+                                </span>
+                            )}
+                            <span className={`inline-flex items-center rounded-full px-2 py-0.5 font-semibold ${dueClasses}`}>
+                                {dueDescriptor}
+                            </span>
+                        </div>
+                    </div>
+                    <div className="flex items-center space-x-4 flex-shrink-0">
+                        <div className="flex items-center space-x-2">
+                            <span className="text-xs text-slate-500">Assignee:</span>
+                            <select
+                                value={task.assigned_to_user_id}
+                                onChange={event =>
+                                    onTaskUpdate(task.action_item_id, task.opportunityId, {
+                                        assigned_to_user_id: event.target.value,
+                                    })
+                                }
+                                className="text-sm p-1 border border-slate-300 rounded-md bg-white w-32"
+                                onClick={event => event.stopPropagation()}
+                            >
+                                {users.map(user => (
+                                    <option key={user.user_id} value={user.user_id}>
+                                        {user.name}
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
+                        <input
+                            type="date"
+                            value={task.due_date}
+                            onChange={event =>
+                                onTaskUpdate(task.action_item_id, task.opportunityId, { due_date: event.target.value })
+                            }
+                            className="text-sm p-1 border border-slate-300 rounded-md bg-white hidden sm:block w-36"
+                            onClick={event => event.stopPropagation()}
+                        />
+                        <select
+                            value={task.status}
+                            onChange={event =>
+                                onTaskUpdate(task.action_item_id, task.opportunityId, {
+                                    status: event.target.value as ActionItemStatus,
+                                })
+                            }
+                            className="text-sm p-1 border border-slate-300 rounded-md bg-white"
+                            onClick={event => event.stopPropagation()}
+                        >
+                            {Object.values(ActionItemStatus).map(status => (
+                                <option key={status} value={status}>
+                                    {status}
+                                </option>
+                            ))}
                         </select>
                     </div>
-                    <input type="date" value={task.due_date} onChange={(e) => onTaskUpdate(task.action_item_id, task.opportunityId, { due_date: e.target.value })} className="text-sm p-1 border border-slate-300 rounded-md bg-white hidden sm:block w-36" onClick={(e) => e.stopPropagation()} />
-                    <select value={task.status} onChange={(e) => onTaskUpdate(task.action_item_id, task.opportunityId, { status: e.target.value as ActionItemStatus })} className="text-sm p-1 border border-slate-300 rounded-md bg-white" onClick={(e) => e.stopPropagation()}>
-                        {Object.values(ActionItemStatus).map(s => <option key={s} value={s}>{s}</option>)}
-                    </select>
                 </div>
+                {task.notes && (
+                    <div className="mt-2 pt-2 border-t border-slate-100 text-xs text-slate-600">
+                        <p className="whitespace-pre-wrap">{task.notes}</p>
+                    </div>
+                )}
+                {task.documents && task.documents.length > 0 && (
+                    <div className="mt-2 pt-2 border-t border-slate-100">
+                        <h4 className="text-xs font-bold text-slate-500 mb-1">Documents:</h4>
+                        <ul className="text-xs space-y-1">
+                            {task.documents.map(doc => (
+                                <li key={doc.id}>
+                                    <a
+                                        href={doc.url}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="text-indigo-600 hover:underline flex items-center space-x-1"
+                                    >
+                                        {ICONS.link}
+                                        <span>{doc.text || doc.url}</span>
+                                    </a>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                )}
             </div>
-            {task.notes && <div className="mt-2 pt-2 border-t border-slate-100 text-xs text-slate-600"><p className="whitespace-pre-wrap">{task.notes}</p></div>}
-            {task.documents && task.documents.length > 0 && (
-                <div className="mt-2 pt-2 border-t border-slate-100">
-                    <h4 className="text-xs font-bold text-slate-500 mb-1">Documents:</h4>
-                    <ul className="text-xs space-y-1">{task.documents.map(doc => (<li key={doc.id}><a href={doc.url} target="_blank" rel="noopener noreferrer" className="text-indigo-600 hover:underline flex items-center space-x-1">{ICONS.link}<span>{doc.text || doc.url}</span></a></li>))}</ul>
-                </div>
-            )}
-        </div>
-    );
+        );
+    };
 
     const renderGroupedView = () => (
         <div className="space-y-6">{Object.entries(groupedTasksByOpportunity).map(([groupName, tasksInGroup]) => (<div key={groupName}><h3 className="text-lg font-bold text-slate-700 mb-2 cursor-pointer hover:text-indigo-600 truncate" onClick={() => onSelectOpportunity(tasksInGroup[0].opportunityId)} title={`View: ${groupName}`}>{groupName}</h3><div className="space-y-2 pl-4 border-l-2 border-slate-200">{tasksInGroup.map(renderTaskItem)}</div></div>))}</div>

--- a/components/__tests__/OpportunityDetail.staging.test.tsx
+++ b/components/__tests__/OpportunityDetail.staging.test.tsx
@@ -78,11 +78,10 @@ describe('OpportunityDetail staging defaults', () => {
     const servicesFitBtn = screen.getByRole('button', { name: /services fit/i });
     fireEvent.click(servicesFitBtn);
 
-    // Expect staged defaults to appear (collapsed rows with Pending save label)
-    // Use one of the canonical defaults
-    expect(screen.getAllByText(/Pending save/i).length).toBeGreaterThan(0);
-    // The staged task title input may be collapsed; ensure the text exists in the DOM
-    expect(screen.getAllByText(/Contact Opp Owner/i).length).toBeGreaterThan(0);
+    // Expect staged defaults to appear with unsaved indicator
+    expect(screen.getAllByText(/unsaved task/i).length).toBeGreaterThan(0);
+    // The staged task title appears as an editable input
+    expect(screen.getAllByDisplayValue(/Contact Opp Owner/i).length).toBeGreaterThan(0);
   });
 
   it('persists staged defaults via the save CTA and shows a success toast', async () => {
@@ -92,7 +91,7 @@ describe('OpportunityDetail staging defaults', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /services fit/i }));
 
-    const saveButton = await screen.findByRole('button', { name: /save action plan/i });
+    const saveButton = await screen.findByRole('button', { name: /save changes/i });
     fireEvent.click(saveButton);
 
     await waitFor(() => {
@@ -100,7 +99,7 @@ describe('OpportunityDetail staging defaults', () => {
     });
     expect(showToastSpy).toHaveBeenCalledWith('Action plan saved', 'success');
     await waitFor(() => {
-      expect(screen.queryByText(/Pending save/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/unsaved task/i)).not.toBeInTheDocument();
     });
   });
 
@@ -116,7 +115,7 @@ describe('OpportunityDetail staging defaults', () => {
 
     expect(confirmSpy).toHaveBeenCalled();
     expect(onBack).not.toHaveBeenCalled();
-    expect(screen.getAllByText(/Pending save/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/unsaved task/i).length).toBeGreaterThan(0);
     confirmSpy.mockRestore();
   });
 
@@ -130,7 +129,7 @@ describe('OpportunityDetail staging defaults', () => {
     fireEvent.click(screen.getByRole('button', { name: /no action needed/i }));
 
     expect(confirmSpy).toHaveBeenCalled();
-    expect(screen.getAllByText(/Pending save/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/unsaved task/i).length).toBeGreaterThan(0);
     confirmSpy.mockRestore();
   });
 
@@ -144,7 +143,7 @@ describe('OpportunityDetail staging defaults', () => {
     fireEvent.click(screen.getByRole('button', { name: /support/i }));
 
     expect(confirmSpy).toHaveBeenCalled();
-    expect(screen.getAllByText(/Pending save/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/unsaved task/i).length).toBeGreaterThan(0);
     confirmSpy.mockRestore();
   });
   it('shows save bar for disposition edits and hides after commit', async () => {
@@ -175,12 +174,12 @@ describe('OpportunityDetail staging defaults', () => {
     fireEvent.click(screen.getByRole('button', { name: /services fit/i }));
 
     expect(await screen.findByText(/unsaved disposition and action plan changes/i)).toBeInTheDocument();
-    expect(screen.getAllByText(/pending save/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/unsaved task/i).length).toBeGreaterThan(0);
 
     fireEvent.click(screen.getByRole('button', { name: /discard changes/i }));
 
     await waitFor(() => {
-      expect(screen.queryByText(/pending save/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/unsaved task/i)).not.toBeInTheDocument();
     });
     expect(screen.queryByText(/unsaved/i)).not.toBeInTheDocument();
   });

--- a/components/disposition/dateUtils.ts
+++ b/components/disposition/dateUtils.ts
@@ -1,0 +1,84 @@
+const MS_IN_DAY = 1000 * 60 * 60 * 24;
+
+const normalizeToLocalDay = (date: Date) => new Date(date.getFullYear(), date.getMonth(), date.getDate());
+
+const parseDueDate = (value?: string | null): Date | null => {
+    if (!value) return null;
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) return null;
+    return normalizeToLocalDay(parsed);
+};
+
+const today = () => normalizeToLocalDay(new Date());
+
+export type DueDateStatus = 'no-due-date' | 'overdue' | 'due-soon' | 'upcoming' | 'due-later';
+
+export const getDueDateStatus = (dueDate?: string | null): DueDateStatus => {
+    const parsed = parseDueDate(dueDate);
+    if (!parsed) {
+        return 'no-due-date';
+    }
+
+    const now = today();
+    const diffDays = Math.round((parsed.getTime() - now.getTime()) / MS_IN_DAY);
+
+    if (diffDays < 0) return 'overdue';
+    if (diffDays === 0) return 'due-soon';
+    if (diffDays <= 3) return 'due-soon';
+    if (diffDays <= 7) return 'upcoming';
+    return 'due-later';
+};
+
+export const getDueDateColorClasses = (dueDate?: string | null): string => {
+    switch (getDueDateStatus(dueDate)) {
+        case 'overdue':
+            return 'bg-rose-100 text-rose-700 border border-rose-200';
+        case 'due-soon':
+            return 'bg-amber-100 text-amber-800 border border-amber-200';
+        case 'upcoming':
+            return 'bg-sky-100 text-sky-800 border border-sky-200';
+        case 'due-later':
+            return 'bg-emerald-100 text-emerald-800 border border-emerald-200';
+        default:
+            return 'bg-slate-100 text-slate-600 border border-slate-200';
+    }
+};
+
+const pluralize = (count: number, singular: string, plural: string) =>
+    `${count} ${count === 1 ? singular : plural}`;
+
+export const getDueDateDescriptor = (dueDate?: string | null): string => {
+    const parsed = parseDueDate(dueDate);
+    if (!parsed) {
+        return 'No due date';
+    }
+
+    const now = today();
+    const diff = Math.round((parsed.getTime() - now.getTime()) / MS_IN_DAY);
+
+    if (diff < -1) {
+        return `${pluralize(Math.abs(diff), 'day', 'days')} overdue`;
+    }
+    if (diff === -1) {
+        return '1 day overdue';
+    }
+    if (diff === 0) {
+        return 'Due today';
+    }
+    if (diff === 1) {
+        return 'Due tomorrow';
+    }
+    if (diff <= 7) {
+        return `Due in ${pluralize(diff, 'day', 'days')}`;
+    }
+
+    return `Due on ${parsed.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}`;
+};
+
+export const formatDueDate = (dueDate?: string | null): string => {
+    const parsed = parseDueDate(dueDate);
+    if (!parsed) {
+        return 'No due date';
+    }
+    return parsed.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+};


### PR DESCRIPTION
## Summary
- redesign the ActionItemsManager to consume context, show inline controls, and flag unsaved staged tasks
- add a due-date utility that returns status classes/descriptors and apply it to action plan rows and the task cockpit
- extend staged action items to carry assignee data, defer save flows to the global Save bar, and refresh unit tests

## Testing
- `npm run test -- --reporter=basic`


------
https://chatgpt.com/codex/tasks/task_b_68d1c1a7c72c832db4ecb2d7fedcfb00